### PR TITLE
refactor SignupFragment to use ViewModel

### DIFF
--- a/app/src/main/java/com/example/hangouts/loginScreen/SignupFragment.java
+++ b/app/src/main/java/com/example/hangouts/loginScreen/SignupFragment.java
@@ -6,8 +6,8 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
 
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -15,19 +15,13 @@ import android.widget.Button;
 import android.widget.Toast;
 
 import com.example.hangouts.databinding.FragmentSignupBinding;
-import com.example.hangouts.homeScreen.MainActivity;
-import com.example.hangouts.models.User;
 import com.example.hangouts.onboardingScreen.OnboardingActivity;
 import com.google.android.material.textfield.TextInputEditText;
-import com.parse.ParseException;
-import com.parse.SignUpCallback;
 
 public class SignupFragment extends Fragment {
 
     private static final String TAG = "SignupFragment";
     FragmentSignupBinding binding;
-
-    final LoginActivity activity = (LoginActivity) getActivity();
 
     private TextInputEditText itName;
     private TextInputEditText itLastName;
@@ -35,8 +29,34 @@ public class SignupFragment extends Fragment {
     private TextInputEditText itPassword;
 
     private Button btnSignup;
+    private SignupViewModel model = null;
 
-    public SignupFragment() {}
+    public SignupFragment() {
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        model = new ViewModelProvider(this).get(SignupViewModel.class);
+        model.actions.observe(this, this::handleAction);
+    }
+
+    private void handleAction(SignupViewModel.Actions actions) {
+        switch (actions) {
+            case TOAST_ALL_FIELDS_REQUIRED:
+                Toast.makeText(
+                        getContext(), "All fields are required", Toast.LENGTH_LONG).show();
+                break;
+            case TOAST_ERROR_SIGNING_UP:
+                Toast.makeText(
+                        getContext(), "Error signing up, try different username",
+                        Toast.LENGTH_LONG).show();
+                break;
+            case NAVIGATE_TO_ONBOARDING_ACTIVITY:
+                goOnboardingActivity();
+                break;
+        }
+    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
@@ -54,48 +74,16 @@ public class SignupFragment extends Fragment {
         itPassword = binding.itSignupPassword;
 
         btnSignup = binding.btnSignup;
-        btnSignup.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                final String name = itName.getText().toString();
-                final String lastName = itLastName.getText().toString();
-                final String username = itUsername.getText().toString();
-                final String password = itPassword.getText().toString();
-                if(name.isEmpty() || lastName.isEmpty() ||
-                        username.isEmpty() || password.isEmpty()){
-                    Toast.makeText(
-                            getContext(), "All fields are required", Toast.LENGTH_LONG).show();
-                }else{
-                    signupUser(name, lastName, username, password);
-                }
-            }
+        btnSignup.setOnClickListener(view1 -> {
+            final String name = itName.getText().toString();
+            final String lastName = itLastName.getText().toString();
+            final String username = itUsername.getText().toString();
+            final String password = itPassword.getText().toString();
+            model.onSignupClick(name, lastName, username, password);
         });
     }
 
-    private void signupUser(String name, String lastName, String username, String password) {
-        User user = new User();
-        user.setUsername(username);
-        user.setPassword(password);
-        user.put(User.KEY_NAME, name);
-        user.put(User.KEY_LASTNAME, lastName);
-
-        user.signUpInBackground(new SignUpCallback() {
-            @Override
-            public void done(ParseException e) {
-                if(e != null){
-                    Log.e(TAG, "Error signing up user: ", e);
-                    Toast.makeText(
-                            getContext(), "Error signing up, try different username",
-                            Toast.LENGTH_LONG).show();
-                }else{
-                    Log.d(TAG, "Signup Successful");
-                    goOnboardingActivity();
-                }
-            }
-        });
-    }
-
-    public void goOnboardingActivity(){
+    private void goOnboardingActivity() {
         Intent intent = new Intent(getContext(), OnboardingActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         startActivity(intent);

--- a/app/src/main/java/com/example/hangouts/loginScreen/SignupViewModel.java
+++ b/app/src/main/java/com/example/hangouts/loginScreen/SignupViewModel.java
@@ -1,0 +1,53 @@
+package com.example.hangouts.loginScreen;
+
+import android.util.Log;
+
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+import com.example.hangouts.models.User;
+
+/**
+ * ViewModel for SignupFragment
+ */
+public class SignupViewModel extends ViewModel {
+    private static final String TAG = "SignupViewModel";
+
+    MutableLiveData<Actions> actions = new MutableLiveData();
+
+    public void onSignupClick(String name, String lastName, String username, String password) {
+        if (name.isEmpty() || lastName.isEmpty() ||
+                username.isEmpty() || password.isEmpty()) {
+            actions.postValue(Actions.TOAST_ALL_FIELDS_REQUIRED);
+        } else {
+            signupUser(name, lastName, username, password);
+        }
+    }
+
+    private void signupUser(String name, String lastName, String username, String password) {
+        User user = new User();
+        user.setUsername(username);
+        user.setPassword(password);
+        user.put(User.KEY_NAME, name);
+        user.put(User.KEY_LASTNAME, lastName);
+
+        user.signUpInBackground(e -> {
+            if (e != null) {
+                actions.postValue(Actions.TOAST_ERROR_SIGNING_UP);
+                Log.e(TAG, "Error signing up user: ", e);
+            } else {
+                Log.d(TAG, "Signup Successful");
+                actions.postValue(Actions.TOAST_ERROR_SIGNING_UP);
+            }
+        });
+    }
+
+    /**
+     * Actions sent to Fragment for 'one-shot' events
+     */
+    enum Actions {
+        TOAST_ALL_FIELDS_REQUIRED,
+        TOAST_ERROR_SIGNING_UP,
+        NAVIGATE_TO_ONBOARDING_ACTIVITY
+    }
+}


### PR DESCRIPTION
Here is a basic setup for ViewModel with SignupFragment.
A few rules for ViewModel:
 - context/activity/view code does not belong here
 - several approaches a popular/typical is a stream of ViewState objects the view renders, and a 'Actions' for one-shot events. Actions are used here.  The View content doesn't really change, so there is no stream of `ViewStates`. 
 
 I built and tested and for some reason kept getting an error of user already existed, even though I changed the name and checked the user object, so not sure what is happing there.