### PR TITLE
Approximation of inverse error function finite series method

### DIFF
--- a/app/src/main/java/com/example/hangouts/BayesianRating.java
+++ b/app/src/main/java/com/example/hangouts/BayesianRating.java
@@ -5,6 +5,7 @@ import org.apache.commons.math3.util.FastMath;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class BayesianRating {
@@ -13,6 +14,7 @@ public class BayesianRating {
     final static int standardStdDeviation = 1;
 
     private static double getPpf(double x) {
+        System.out.println(inverseCumulativeProbability(x));
         return inverseCumulativeProbability(x);
     }
 
@@ -84,32 +86,41 @@ public class BayesianRating {
     /***
      * Approximating the inverse error function with the Taylor Finite Series method,
      * first 23 terms.
+     *
+     * Terms are obtained with the Taylor Power Series as described in: https://dlmf.nist.gov/7.17
      */
+    private static final List<Double> TAYLOR_EXPANSION_TERMS = Arrays
+            .asList(0.8862269254527579,
+                    0.23201366653465444,
+                    0.12755617530559793,
+                    0.08655212924154752,
+                    0.0649596177453854,
+                    0.051731281984616365,
+                    0.04283672065179733,
+                    0.03646592930853161,
+                    0.03168900502160544,
+                    0.027980632964995214,
+                    0.025022275841198347,
+                    0.02260986331889757,
+                    0.020606780379058987,
+                    0.01891821725077884,
+                    0.017476370562856534,
+                    0.01623150098768524,
+                    0.015146315063247798,
+                    0.014192316002509954,
+                    0.013347364197421288,
+                    0.012594004871332063,
+                    0.011918295936392034,
+                    0.011308970105922531,
+                    0.010756825303317953,
+                    0.010254274081853464,
+                    0.009795005770071162);
+
     private static double inverseErrorFunction(double x) {
-        return 0.8862269254527579 * x
-                + 0.23201366653465444 *  FastMath.pow(x,3)
-                + 0.12755617530559793 *  FastMath.pow(x,5)
-                + 0.08655212924154752 *  FastMath.pow(x,7)
-                + 0.0649596177453854 *  FastMath.pow(x,9)
-                + 0.051731281984616365 *  FastMath.pow(x,11)
-                + 0.04283672065179733 *  FastMath.pow(x,13)
-                + 0.03646592930853161 *  FastMath.pow(x,15)
-                + 0.03168900502160544 *  FastMath.pow(x,17)
-                + 0.027980632964995214 *  FastMath.pow(x,19)
-                + 0.025022275841198347 *  FastMath.pow(x,21)
-                + 0.02260986331889757 *  FastMath.pow(x,23)
-                + 0.020606780379058987 *  FastMath.pow(x,25)
-                + 0.01891821725077884 *  FastMath.pow(x,27)
-                + 0.017476370562856534 *  FastMath.pow(x,29)
-                + 0.01623150098768524 *  FastMath.pow(x,31)
-                + 0.015146315063247798 *  FastMath.pow(x,33)
-                + 0.014192316002509954 *  FastMath.pow(x,35)
-                + 0.013347364197421288 *  FastMath.pow(x,37)
-                + 0.012594004871332063 *  FastMath.pow(x,39)
-                + 0.011918295936392034 *  FastMath.pow(x,41)
-                + 0.011308970105922531 *  FastMath.pow(x,43)
-                + 0.010756825303317953 *  FastMath.pow(x,45)
-                + 0.010254274081853464 *  FastMath.pow(x,47)
-                + 0.009795005770071162 *  FastMath.pow(x,49);
+        double result = TAYLOR_EXPANSION_TERMS.get(0) * x;
+        for(int i = 1; i < TAYLOR_EXPANSION_TERMS.size(); i++){
+            result += TAYLOR_EXPANSION_TERMS.get(i) * FastMath.pow(x, 2*i+1);
+        }
+        return result;
     }
 }

--- a/app/src/main/java/com/example/hangouts/BayesianRating.java
+++ b/app/src/main/java/com/example/hangouts/BayesianRating.java
@@ -1,18 +1,19 @@
 package com.example.hangouts;
 
 import org.apache.commons.math3.distribution.NormalDistribution;
+import org.apache.commons.math3.util.FastMath;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 
 public class BayesianRating {
 
     final static int standardNormalMean = 0;
     final static int standardStdDeviation = 1;
-    final static NormalDistribution standardNormalDist = new NormalDistribution(standardNormalMean,
-            standardStdDeviation);
 
     private static double getPpf(double x) {
-        return standardNormalDist.inverseCumulativeProbability(x);
+        return inverseCumulativeProbability(x);
     }
 
     public static double getBayesianRating(List<Double> list, double significance) {
@@ -24,14 +25,91 @@ public class BayesianRating {
         if (sum == 0) {
             return 0;
         }
-        double z_value = getPpf(1 - (1 - significance) / 2);
+        double zValue = getPpf(1 - (1 - significance) / 2);
         double firstTerm = 0;
         double secondTerm = 0;
         for (int i = 0; i < size; i++) {
             firstTerm += (i + 1) * (list.get(i) + 1) / (sum + size);
             secondTerm += (i + 1) * (i + 1) * (list.get(i) + 1) / (sum + size);
         }
-        return firstTerm - z_value *
-                Math.sqrt((secondTerm - firstTerm*firstTerm)/(sum + size + 1));
+        return firstTerm - zValue *
+                Math.sqrt((secondTerm - firstTerm * firstTerm) / (sum + size + 1));
+    }
+
+    private static double inverseCumulativeProbability(double x) {
+        return FastMath.sqrt(2.0) * inverseErrorFunction(2 * x - 1);
+    }
+
+    /***
+     * The algorithm to approximate the error inverse function with the finite series method
+     * would look like this, however not only this is not computationally inefficient,
+     * the precision of the double data type won't be able to handle the calculations after the
+     * third term.
+     * final static double SQRTPI_OVER_TWO = FastMath.sqrt(FastMath.PI) / 2;
+     *  final double epsilon = 0.001;
+     *         double diff = 1;
+     *
+     *         ArrayList<Double> terms = new ArrayList<Double>();
+     *         terms.add(SQRTPI_OVER_TWO * x);
+     *         double sum = 0.0;
+     *         // First Term
+     *         double prevTerm = SQRTPI_OVER_TWO;
+     *         // c is numerator
+     *         List<Double> c = new ArrayList<>();
+     *         c.add(1.0);
+     *         int k = 1;
+     *         while (diff > epsilon) {
+     *
+     *             // get numerator
+     *             System.out.println("k = " + k);
+     *             double cSum = 0;
+     *             for (int m = 0; m < k; m++) {
+     *                 System.out.println("m = " + m);
+     *                 double newTerm = (c.get(m) * c.get(k - 1 - m)) / ((m + 1) * (2 * m + 1));
+     *                 cSum += newTerm;
+     *                 c.add(newTerm);
+     *             }
+     *
+     *             double newTerm = (cSum / (2 * k + 1)) * FastMath.pow((SQRTPI_OVER_TWO) * x,
+     *                     (2 * k + 1));
+     *             sum += newTerm;
+     *             diff = prevTerm - newTerm;
+     *             prevTerm = newTerm;
+     *             System.out.println("New Term = " + newTerm);
+     *             k++;
+     *         }
+     *         return sum;
+     */
+
+    /***
+     * Approximating the inverse error function with the Taylor Finite Series method,
+     * first 23 terms.
+     */
+    private static double inverseErrorFunction(double x) {
+        return 0.8862269254527579 * x
+                + 0.23201366653465444 *  FastMath.pow(x,3)
+                + 0.12755617530559793 *  FastMath.pow(x,5)
+                + 0.08655212924154752 *  FastMath.pow(x,7)
+                + 0.0649596177453854 *  FastMath.pow(x,9)
+                + 0.051731281984616365 *  FastMath.pow(x,11)
+                + 0.04283672065179733 *  FastMath.pow(x,13)
+                + 0.03646592930853161 *  FastMath.pow(x,15)
+                + 0.03168900502160544 *  FastMath.pow(x,17)
+                + 0.027980632964995214 *  FastMath.pow(x,19)
+                + 0.025022275841198347 *  FastMath.pow(x,21)
+                + 0.02260986331889757 *  FastMath.pow(x,23)
+                + 0.020606780379058987 *  FastMath.pow(x,25)
+                + 0.01891821725077884 *  FastMath.pow(x,27)
+                + 0.017476370562856534 *  FastMath.pow(x,29)
+                + 0.01623150098768524 *  FastMath.pow(x,31)
+                + 0.015146315063247798 *  FastMath.pow(x,33)
+                + 0.014192316002509954 *  FastMath.pow(x,35)
+                + 0.013347364197421288 *  FastMath.pow(x,37)
+                + 0.012594004871332063 *  FastMath.pow(x,39)
+                + 0.011918295936392034 *  FastMath.pow(x,41)
+                + 0.011308970105922531 *  FastMath.pow(x,43)
+                + 0.010756825303317953 *  FastMath.pow(x,45)
+                + 0.010254274081853464 *  FastMath.pow(x,47)
+                + 0.009795005770071162 *  FastMath.pow(x,49);
     }
 }

--- a/app/src/main/java/com/example/hangouts/homeScreen/MainActivity.java
+++ b/app/src/main/java/com/example/hangouts/homeScreen/MainActivity.java
@@ -24,9 +24,6 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
 
         Places.initialize(getApplicationContext(), BuildConfig.GOOGLE_CLOUD_API_KEY);
-        List<Double> italian = Arrays.asList(1.0, 1.0, 2.0, 0.0, 0.0, 0.0);
-        double rating = BayesianRating.getBayesianRating(italian, 0.95);
-        Log.d(TAG, "onCreate: " + String.valueOf(rating));
-        Toast.makeText(this, String.valueOf(rating), Toast.LENGTH_SHORT).show();
+
     }
 }

--- a/app/src/main/java/com/example/hangouts/homeScreen/MainActivity.java
+++ b/app/src/main/java/com/example/hangouts/homeScreen/MainActivity.java
@@ -24,6 +24,9 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
 
         Places.initialize(getApplicationContext(), BuildConfig.GOOGLE_CLOUD_API_KEY);
-
+        List<Double> italian = Arrays.asList(1.0, 1.0, 2.0, 0.0, 0.0, 0.0);
+        double rating = BayesianRating.getBayesianRating(italian, 0.95);
+        Log.d(TAG, "onCreate: " + String.valueOf(rating));
+        Toast.makeText(this, String.valueOf(rating), Toast.LENGTH_SHORT).show();
     }
 }


### PR DESCRIPTION
My implementation on the method used to calculate the inverseCumulativeProbability. The key is the inverse error function. There are many ways to approximate this function, one using the finite Taylor series method.

<img width="653" alt="Screen Shot 2022-07-21 at 9 29 21 PM" src="https://user-images.githubusercontent.com/62727899/180363147-010d36ed-3870-4726-9431-d2dbcfdf7599.png">

However, it is not possible to translate the series to code using java's primitive datatypes, precision would be lost within a few terms. Calculating a few terms by hand and then using a specialized calculator, I was able to get the first 23 terms which will be enough to have an approximation close enough to the third party library serve the purpose.

<img width="325" alt="Screen Shot 2022-07-21 at 9 14 31 PM" src="https://user-images.githubusercontent.com/62727899/180363199-bb8f3238-4bc0-40ac-9215-6f1ec2977daa.png">

The first print statement is my approximation and the second one is the third party library's method.